### PR TITLE
Add basic league creation flow with fixtures

### DIFF
--- a/app/leagues/[id]/page.tsx
+++ b/app/leagues/[id]/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { generateRoundRobin } from '@/lib/scheduler';
+
+type League = { id:string; sport:'Padel'|'Tennis'; name:string; location?:string; start:string; end:string; teams:string[] };
+
+export default function LeaguePage() {
+  const { id } = useParams<{id:string}>();
+  const [league, setLeague] = useState<League | null>(null);
+  const [fixtures, setFixtures] = useState<ReturnType<typeof generateRoundRobin>>([]);
+
+  useEffect(() => {
+    const raw = typeof window !== 'undefined' ? localStorage.getItem(`league:${id}`) : null;
+    if (raw) setLeague(JSON.parse(raw));
+  }, [id]);
+
+  useEffect(() => {
+    if (league) {
+      const fxs = generateRoundRobin(
+        league.teams.map((_,i)=>`t${i}`),
+        league.start,
+        1,
+        league.location
+      ).map((f,i)=>({ ...f, teamA: league.teams[Number(f.teamA.slice(1))], teamB: league.teams[Number(f.teamB.slice(1))] }));
+      setFixtures(fxs);
+    }
+  }, [league]);
+
+  if (!league) return <main className="p-6">Loading…</main>;
+
+  return (
+    <main className="max-w-5xl mx-auto p-6 space-y-6">
+      <header className="flex items-center gap-3">
+        <h1 className="text-2xl font-semibold">{league.name}</h1>
+        <Badge variant="secondary">{league.sport}</Badge>
+      </header>
+
+      <Card>
+        <CardHeader><CardTitle>Fixtures</CardTitle></CardHeader>
+        <CardContent className="space-y-2">
+          {fixtures.map(f=>(
+            <div key={f.id} className="flex items-center justify-between border rounded-xl p-3">
+              <div>
+                <div className="font-medium">{f.teamA} <span className="text-slate-400">vs</span> {f.teamB}</div>
+                <div className="text-xs text-slate-500">{new Date(f.date!).toLocaleDateString()} • {f.location || 'TBC'}</div>
+              </div>
+              <Button variant="outline" size="sm">Enter score</Button>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/leagues/new/page.tsx
+++ b/app/leagues/new/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+export default function NewLeaguePage() {
+  const [sport, setSport] = useState<'Padel'|'Tennis'>('Padel');
+  const [name, setName] = useState('Autumn Box League');
+  const [location, setLocation] = useState('Riverside Padel & Tennis');
+  const [start, setStart] = useState<string>(new Date().toISOString().slice(0,10));
+  const [end, setEnd] = useState<string>(new Date(Date.now()+28*864e5).toISOString().slice(0,10));
+  const [players, setPlayers] = useState<string>('Team A\nTeam B\nTeam C\nTeam D');
+
+  const create = () => {
+    const id = Math.random().toString(36).slice(2,9);
+    const teams = players.split('\n').map(s=>s.trim()).filter(Boolean);
+    const payload = { id, sport, name, location, start, end, teams };
+    // temp persistence so refresh keeps it
+    localStorage.setItem(`league:${id}`, JSON.stringify(payload));
+    window.location.href = `/leagues/${id}`;
+  };
+
+  return (
+    <main className="max-w-3xl mx-auto p-6">
+      <Card>
+        <CardHeader><CardTitle>Create a League</CardTitle></CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label>Sport</Label>
+            <div className="mt-2 inline-flex rounded-xl border p-1">
+              {(['Padel','Tennis'] as const).map(s=>(
+                <Button key={s} variant={sport===s?'default':'ghost'} onClick={()=>setSport(s)} className="rounded-xl">{s}</Button>
+              ))}
+            </div>
+          </div>
+          <div><Label>Name</Label><Input className="mt-2" value={name} onChange={e=>setName(e.target.value)} /></div>
+          <div><Label>Location</Label><Input className="mt-2" value={location} onChange={e=>setLocation(e.target.value)} /></div>
+          <div className="grid grid-cols-2 gap-4">
+            <div><Label>Start</Label><Input className="mt-2" type="date" value={start} onChange={e=>setStart(e.target.value)} /></div>
+            <div><Label>End</Label><Input className="mt-2" type="date" value={end} onChange={e=>setEnd(e.target.value)} /></div>
+          </div>
+          <div>
+            <Label>Teams / Players (one per line)</Label>
+            <textarea className="mt-2 w-full rounded-xl border border-slate-200 p-2 text-sm" rows={6} value={players} onChange={e=>setPlayers(e.target.value)} />
+          </div>
+          <Button onClick={create}>Create League</Button>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,10 @@
+import Link from 'next/link';
+
 export default function Home() {
-  return <h1 style={{ padding: 24, fontSize: 28 }}>Hello League Builder 🚀</h1>;
+  return (
+    <main className="min-h-screen p-6">
+      <h1 className="text-2xl font-semibold mb-4">League Builder</h1>
+      <Link className="underline" href="/leagues/new">Create a league →</Link>
+    </main>
+  );
 }

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -1,0 +1,21 @@
+export type Fixture = {
+  id: string; round: number; teamA: string; teamB: string; date?: string; location?: string;
+};
+const uid = () => Math.random().toString(36).slice(2,9);
+
+export function generateRoundRobin(teamIds: string[], startISO: string, weeksGap = 1, location?: string): Fixture[] {
+  const ids = [...teamIds];
+  if (ids.length % 2 === 1) ids.push('BYE');
+  const n = ids.length, rounds = n - 1, out: Fixture[] = [];
+  for (let r=0; r<rounds; r++) {
+    const date = new Date(new Date(startISO).getTime() + r*weeksGap*7*864e5).toISOString();
+    for (let i=0; i<n/2; i++) {
+      const a = ids[i], b = ids[n-1-i];
+      if (a !== 'BYE' && b !== 'BYE') out.push({ id: uid(), round: r+1, teamA: a, teamB: b, date, location });
+    }
+    const fixed = ids[0], rest = ids.slice(1);
+    rest.unshift(rest.pop() as string);
+    ids.splice(0, ids.length, fixed, ...rest);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- add league creation page with localStorage persistence
- add round-robin fixture scheduler util
- display fixtures for each league and link from homepage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a1074b08327b9116bbdfb111284