### PR TITLE
feat: configurable tennis sets and visible score input

### DIFF
--- a/app/leagues/[id]/page.tsx
+++ b/app/leagues/[id]/page.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { generateRoundRobin } from '@/lib/scheduler';
 import { computeStandings, type Fixture } from '@/lib/standings';
 
-type League = { id:string; sport:'Padel'|'Tennis'; name:string; location?:string; start:string; end:string; teams:string[] };
+type League = { id:string; sport:'Padel'|'Tennis'; name:string; location?:string; start:string; end:string; teams:string[]; sets:3|5 };
 
 export default function LeaguePage() {
   const { id } = useParams<{id: string}>();
@@ -19,7 +19,7 @@ export default function LeaguePage() {
   useEffect(() => {
     const raw = typeof window !== 'undefined' ? localStorage.getItem(`league:${id}`) : null;
     if (!raw) return;
-    const lg: League = JSON.parse(raw);
+    const lg: League = { sets:3, ...JSON.parse(raw) };
     setLeague(lg);
 
     const stored = localStorage.getItem(`league:${id}:fixtures`);
@@ -88,7 +88,7 @@ export default function LeaguePage() {
           <CardHeader><CardTitle>Fixtures</CardTitle></CardHeader>
           <CardContent className="space-y-3">
             {fixtures.map((f) => (
-              <FixtureRow key={f.id} fixture={f} onSubmit={(sets)=>updateResult(f.id, sets)} />
+              <FixtureRow key={f.id} fixture={f} setCount={league.sets} onSubmit={(sets)=>updateResult(f.id, sets)} />
             ))}
           </CardContent>
         </Card>
@@ -130,23 +130,28 @@ export default function LeaguePage() {
   );
 }
 
-function FixtureRow({ fixture, onSubmit }: {
+function FixtureRow({ fixture, onSubmit, setCount }: {
   fixture: Fixture;
   onSubmit: (sets: Array<{a:number; b:number}>) => void;
+  setCount: number;
 }) {
-  const [s1a, setS1a] = useState<number | ''>(''); const [s1b, setS1b] = useState<number | ''>('');
-  const [s2a, setS2a] = useState<number | ''>(''); const [s2b, setS2b] = useState<number | ''>('');
-  const [s3a, setS3a] = useState<number | ''>(''); const [s3b, setS3b] = useState<number | ''>('');
+  const [scoresA, setScoresA] = useState<(number|'' )[]>(Array(setCount).fill(''));
+  const [scoresB, setScoresB] = useState<(number|'' )[]>(Array(setCount).fill(''));
+
+  useEffect(() => {
+    setScoresA(Array(setCount).fill(''));
+    setScoresB(Array(setCount).fill(''));
+  }, [setCount]);
 
   const submit = () => {
-    const sets = [
-      typeof s1a === 'number' && typeof s1b === 'number' ? { a: s1a, b: s1b } : null,
-      typeof s2a === 'number' && typeof s2b === 'number' ? { a: s2a, b: s2b } : null,
-      typeof s3a === 'number' && typeof s3b === 'number' ? { a: s3a, b: s3b } : null,
-    ].filter(Boolean) as Array<{a:number; b:number}>;
+    const sets = scoresA.map((a, i) => {
+      const b = scoresB[i];
+      return typeof a === 'number' && typeof b === 'number' ? { a, b } : null;
+    }).filter(Boolean) as Array<{a:number; b:number}>;
     if (sets.length === 0) return;
     onSubmit(sets);
-    setS1a(''); setS1b(''); setS2a(''); setS2b(''); setS3a(''); setS3b('');
+    setScoresA(Array(setCount).fill(''));
+    setScoresB(Array(setCount).fill(''));
   };
 
   return (
@@ -162,20 +167,17 @@ function FixtureRow({ fixture, onSubmit }: {
           </Badge>
         ) : (
           <div className="flex items-center gap-2 text-sm">
-            {([
-              [s1a, setS1a, s1b, setS1b],
-              [s2a, setS2a, s2b, setS2b],
-              [s3a, setS3a, s3b, setS3b],
-            ] as [
-              number | '', React.Dispatch<React.SetStateAction<number | ''>>,
-              number | '', React.Dispatch<React.SetStateAction<number | ''>>
-            ][]).map((row, idx) => (
+            {Array.from({length: setCount}).map((_, idx) => (
               <div key={idx} className="flex items-center gap-1">
-                <Input className="w-12" inputMode="numeric" placeholder="6"
-                  value={row[0]} onChange={(e)=>row[1](e.target.value==='' ? '' : Number(e.target.value))} />
+                <Input className="w-12" type="number" inputMode="numeric" placeholder="6"
+                  value={scoresA[idx]}
+                  onChange={(e)=>setScoresA(prev=>{ const next=[...prev]; next[idx]= e.target.value=== '' ? '' : Number(e.target.value); return next; })}
+                />
                 <span className="text-slate-400">-</span>
-                <Input className="w-12" inputMode="numeric" placeholder="4"
-                  value={row[2]} onChange={(e)=>row[3](e.target.value==='' ? '' : Number(e.target.value))} />
+                <Input className="w-12" type="number" inputMode="numeric" placeholder="4"
+                  value={scoresB[idx]}
+                  onChange={(e)=>setScoresB(prev=>{ const next=[...prev]; next[idx]= e.target.value=== '' ? '' : Number(e.target.value); return next; })}
+                />
               </div>
             ))}
           </div>

--- a/app/leagues/new/page.tsx
+++ b/app/leagues/new/page.tsx
@@ -13,11 +13,12 @@ export default function NewLeaguePage() {
   const [start, setStart] = useState<string>(new Date().toISOString().slice(0,10));
   const [end, setEnd] = useState<string>(new Date(Date.now()+28*864e5).toISOString().slice(0,10));
   const [players, setPlayers] = useState<string>('Team A\nTeam B\nTeam C\nTeam D');
+  const [sets, setSets] = useState<3 | 5>(3);
 
   const create = () => {
     const id = Math.random().toString(36).slice(2,9);
     const teams = players.split('\n').map(s=>s.trim()).filter(Boolean);
-    const payload = { id, sport, name, location, start, end, teams };
+    const payload = { id, sport, name, location, start, end, teams, sets };
     // temp persistence so refresh keeps it
     localStorage.setItem(`league:${id}`, JSON.stringify(payload));
     window.location.href = `/leagues/${id}`;
@@ -32,10 +33,25 @@ export default function NewLeaguePage() {
             <Label>Sport</Label>
             <div className="mt-2 inline-flex rounded-xl border p-1">
               {(['Padel','Tennis'] as const).map(s=>(
-                <Button key={s} variant={sport===s?'default':'ghost'} onClick={()=>setSport(s)} className="rounded-xl">{s}</Button>
+                <Button
+                  key={s}
+                  variant={sport===s?'default':'ghost'}
+                  onClick={()=>{ setSport(s); if(s==='Padel') setSets(3); }}
+                  className="rounded-xl"
+                >{s}</Button>
               ))}
             </div>
           </div>
+          {sport === 'Tennis' && (
+            <div>
+              <Label>Sets per match</Label>
+              <div className="mt-2 inline-flex rounded-xl border p-1">
+                {[3,5].map(n => (
+                  <Button key={n} variant={sets===n?'default':'ghost'} onClick={()=>setSets(n)} className="rounded-xl">{n}</Button>
+                ))}
+              </div>
+            </div>
+          )}
           <div><Label>Name</Label><Input className="mt-2" value={name} onChange={e=>setName(e.target.value)} /></div>
           <div><Label>Location</Label><Input className="mt-2" value={location} onChange={e=>setLocation(e.target.value)} /></div>
           <div className="grid grid-cols-2 gap-4">

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,10 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <input
         ref={ref}
-        className={cn('flex h-10 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:opacity-50', className)}
+        className={cn(
+          'flex h-10 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 ring-offset-white placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
         {...props}
       />
     );

--- a/package.json
+++ b/package.json
@@ -6,14 +6,19 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev --name init",
+    "prisma:deploy": "prisma migrate deploy",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "framer-motion": "^11.0.0",
     "lucide-react": "^0.441.0",
     "next": "^14.2.5",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@prisma/client": "^5.18.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.9",
@@ -22,23 +27,7 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.10",
-    "typescript": "^5.5.4"
-  },
-  {
-  "dependencies": {
-    "@prisma/client": "^5.18.0"
-  },
-  "devDependencies": {
+    "typescript": "^5.5.4",
     "prisma": "^5.18.0"
-  },
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev --name init",
-    "prisma:deploy": "prisma migrate deploy",
-    "postinstall": "prisma generate"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,4 +1,6 @@
-generator client { provider = "prisma-client-js" }
+generator client {
+  provider = "prisma-client-js"
+}
 
 datasource db {
   provider  = "postgresql"
@@ -6,9 +8,21 @@ datasource db {
   directUrl = env("DIRECT_URL")
 }
 
-enum Sport { Padel Tennis }
-enum Winner { A B }
-enum ResultStatus { Pending Confirmed Disputed }
+enum Sport {
+  Padel
+  Tennis
+}
+
+enum Winner {
+  A
+  B
+}
+
+enum ResultStatus {
+  Pending
+  Confirmed
+  Disputed
+}
 
 model User {
   id        String   @id @default(cuid())


### PR DESCRIPTION
## Summary
- fix score input text color so numbers display clearly
- allow tennis leagues to choose 3 or 5 sets when creating a league
- render score entry rows based on configured set count

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8b2c25e48327a246e60e94ff1d33