### PR TITLE
Add selectable set counts for tennis and fix score input visibility

### DIFF
--- a/app/leagues/[id]/page.tsx
+++ b/app/leagues/[id]/page.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { generateRoundRobin } from '@/lib/scheduler';
 import { computeStandings, type Fixture } from '@/lib/standings';
 
@@ -169,21 +168,24 @@ function FixtureRow({ fixture, setCount, onSubmit }: {
         ) : (
           <div className="flex items-center gap-2 text-sm">
             {scores.map((s, idx) => (
-              <div key={idx} className="flex items-center gap-1">
-                <Input
-                  className="w-12"
+              <div
+                key={idx}
+                className="flex h-10 overflow-hidden rounded-full border border-slate-200"
+              >
+                <input
+                  className="w-10 text-center text-slate-900 focus:outline-none"
                   inputMode="numeric"
-                  placeholder="6"
+                  placeholder="0"
                   value={s.a}
-                  onChange={(e)=>update(idx,'a',e.target.value)}
+                  onChange={(e) => update(idx, 'a', e.target.value)}
                 />
-                <span className="text-slate-400">-</span>
-                <Input
-                  className="w-12"
+                <div className="w-px bg-slate-200" />
+                <input
+                  className="w-10 text-center text-slate-900 focus:outline-none"
                   inputMode="numeric"
-                  placeholder="4"
+                  placeholder="0"
                   value={s.b}
-                  onChange={(e)=>update(idx,'b',e.target.value)}
+                  onChange={(e) => update(idx, 'b', e.target.value)}
                 />
               </div>
             ))}

--- a/app/leagues/new/page.tsx
+++ b/app/leagues/new/page.tsx
@@ -4,10 +4,10 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export default function NewLeaguePage() {
   const [sport, setSport] = useState<'Padel'|'Tennis'>('Padel');
+  const [sets, setSets] = useState<3|5>(3);
   const [name, setName] = useState('Autumn Box League');
   const [location, setLocation] = useState('Riverside Padel & Tennis');
   const [start, setStart] = useState<string>(new Date().toISOString().slice(0,10));
@@ -17,7 +17,7 @@ export default function NewLeaguePage() {
   const create = () => {
     const id = Math.random().toString(36).slice(2,9);
     const teams = players.split('\n').map(s=>s.trim()).filter(Boolean);
-    const payload = { id, sport, name, location, start, end, teams };
+    const payload = { id, sport, sets: sport === 'Tennis' ? sets : 3, name, location, start, end, teams };
     // temp persistence so refresh keeps it
     localStorage.setItem(`league:${id}`, JSON.stringify(payload));
     window.location.href = `/leagues/${id}`;
@@ -36,6 +36,18 @@ export default function NewLeaguePage() {
               ))}
             </div>
           </div>
+          {sport === 'Tennis' && (
+            <div>
+              <Label>Sets</Label>
+              <div className="mt-2 inline-flex rounded-xl border p-1">
+                {[3,5].map(n => (
+                  <Button key={n} variant={sets===n?'default':'ghost'} onClick={()=>setSets(n as 3|5)} className="rounded-xl">
+                    {n} sets
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
           <div><Label>Name</Label><Input className="mt-2" value={name} onChange={e=>setName(e.target.value)} /></div>
           <div><Label>Location</Label><Input className="mt-2" value={location} onChange={e=>setLocation(e.target.value)} /></div>
           <div className="grid grid-cols-2 gap-4">

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,10 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <input
         ref={ref}
-        className={cn('flex h-10 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:opacity-50', className)}
+        className={cn(
+          'flex h-10 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 ring-offset-white placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
         {...props}
       />
     );


### PR DESCRIPTION
## Summary
- allow league creation to choose 3 or 5 sets for tennis and store configuration
- render appropriate number of set inputs for fixtures
- ensure score text is visible in inputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9768df54832780195983b0e02865